### PR TITLE
Add tests for map and env utilities

### DIFF
--- a/tests/test_env_methods.py
+++ b/tests/test_env_methods.py
@@ -1,0 +1,28 @@
+import numpy as np
+from v2.red_gym_env_v2 import RedGymEnv
+
+
+def make_env(freqs=4):
+    env = RedGymEnv.__new__(RedGymEnv)
+    env.enc_freqs = freqs
+    return env
+
+
+def test_bit_count():
+    env = make_env()
+    assert env.bit_count(0b0) == 0
+    assert env.bit_count(0b1011) == 3
+    assert env.bit_count(255) == 8
+
+
+def test_fourier_encode_zero():
+    env = make_env(4)
+    result = env.fourier_encode(0)
+    assert np.allclose(result, np.zeros(4))
+
+
+def test_fourier_encode_values():
+    env = make_env(3)
+    val = np.pi / 2
+    expected = np.sin(val * 2 ** np.arange(3))
+    assert np.allclose(env.fourier_encode(val), expected)

--- a/tests/test_global_map.py
+++ b/tests/test_global_map.py
@@ -1,0 +1,16 @@
+import pytest
+from v2.global_map import local_to_global, MAP_DATA, GLOBAL_MAP_SHAPE, MAP_ROW_OFFSET, MAP_COL_OFFSET
+
+
+def test_local_to_global_valid():
+    map_n = 0
+    r, c = 5, 10
+    gy, gx = local_to_global(r, c, map_n)
+    map_x, map_y = MAP_DATA[map_n]["coordinates"]
+    assert gy == r + map_y + MAP_ROW_OFFSET
+    assert gx == c + map_x + MAP_COL_OFFSET
+
+
+def test_local_to_global_invalid():
+    gy, gx = local_to_global(0, 0, 9999)
+    assert (gy, gx) == (GLOBAL_MAP_SHAPE[0] // 2, GLOBAL_MAP_SHAPE[1] // 2)


### PR DESCRIPTION
## Summary
- add `tests/` directory with unit tests
- test `local_to_global` for valid and invalid map IDs
- test `bit_count` and `fourier_encode` utility methods

## Testing
- `pytest -q` *(fails: command not found)*