### PR TITLE
Fix baseline env import

### DIFF
--- a/baselines/baseline_fast_minimal.py
+++ b/baselines/baseline_fast_minimal.py
@@ -9,7 +9,8 @@ from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
 from tensorboard_callback import TensorboardCallback
 
-from red_gym_env_v3_minimal import PokeRedEnv
+# Import the minimal PokeRed environment
+from red_gym_env_minimal import PokeRedEnv
 from stream_agent_wrapper import StreamWrapper
 
 def make_env(rank, seed=0):


### PR DESCRIPTION
## Summary
- fix wrong env import in baseline_fast_minimal

## Testing
- `python -m py_compile baselines/baseline_fast_minimal.py`
- `python baselines/baseline_fast_minimal.py` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*