### PR TITLE
Ignore zipped run checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ session_*
 PokemonRed.gb.state
 venv*
 .python-version
+*/runs/*.zip


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore zipped checkpoints in any `runs` directory

## Testing
- `git status --short`