### PR TITLE
Add episode return logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,21 @@ https://github.com/pwhiddy/pokerl-map-viz/
 The current state of each game is rendered to images in the session directory.   
 You can track the progress in tensorboard by moving into the session directory and running:  
 ```tensorboard --logdir .```  
-You can then navigate to `localhost:6006` in your browser to view metrics.  
+You can then navigate to `localhost:6006` in your browser to view metrics.
 To enable wandb integration, change `use_wandb_logging` in the training script to `True`.
+
+To programmatically access the logged values you can use TensorBoard's event
+accumulator. This lets you query the episode return histogram and other
+statistics directly from the log files:
+
+```python
+from tensorboard.backend.event_processing import event_accumulator
+
+ea = event_accumulator.EventAccumulator("runs/histogram")
+ea.Reload()
+print(ea.Scalars("episode_return/mean")[-1])
+print(ea.Histograms("env_stats_distribs/coord_count")[-1])
+```
 
 ## Static Visualization 🐜
 Map visualization code can be found in `visualization/` directory.

--- a/baselines/tensorboard_callback.py
+++ b/baselines/tensorboard_callback.py
@@ -43,7 +43,11 @@ class TensorboardCallback(BaseCallback):
             all_infos = self.training_env.get_attr("agent_stats")
             all_final_infos = [stats[-1] for stats in all_infos]
             mean_infos, distributions = merge_dicts(all_final_infos)
-            # TODO log distributions, and total return
+
+            returns = np.array(self.training_env.get_attr("total_reward"), dtype=float)
+            self.writer.add_histogram("episode_return/distribution", returns, self.n_calls)
+            self.logger.record("episode_return/mean", float(returns.mean()))
+
             for key, val in mean_infos.items():
                 self.logger.record(f"env_stats/{key}", val)
 
@@ -70,5 +74,7 @@ class TensorboardCallback(BaseCallback):
     
     def _on_training_end(self):
         if self.writer:
+            self.writer.flush()
             self.writer.close()
+            self.writer = None
 

--- a/v2/tensorboard_callback.py
+++ b/v2/tensorboard_callback.py
@@ -43,7 +43,11 @@ class TensorboardCallback(BaseCallback):
             all_infos = self.training_env.get_attr("agent_stats")
             all_final_infos = [stats[-1] for stats in all_infos]
             mean_infos, distributions = merge_dicts(all_final_infos)
-            # TODO log distributions, and total return
+
+            returns = np.array(self.training_env.get_attr("total_reward"), dtype=float)
+            self.writer.add_histogram("episode_return/distribution", returns, self.n_calls)
+            self.logger.record("episode_return/mean", float(returns.mean()))
+
             for key, val in mean_infos.items():
                 self.logger.record(f"env_stats/{key}", val)
 
@@ -70,5 +74,7 @@ class TensorboardCallback(BaseCallback):
     
     def _on_training_end(self):
         if self.writer:
+            self.writer.flush()
             self.writer.close()
+            self.writer = None
 


### PR DESCRIPTION
## Summary
- log episode return distributions for baselines and v2
- flush histogram writers on training end
- document how to access logged metrics programmatically

## Testing
- `python -m py_compile v2/tensorboard_callback.py baselines/tensorboard_callback.py`