### PR TITLE
Fix websocket reconnection and counters

### DIFF
--- a/baselines/stream_agent_wrapper.py
+++ b/baselines/stream_agent_wrapper.py
@@ -1,6 +1,7 @@
 import asyncio
 import websockets
 import json
+import logging
 
 import gymnasium as gym
 
@@ -19,7 +20,7 @@ class StreamWrapper(gym.Wrapper):
             self.establish_wc_connection()
         )
         self.upload_interval = 300
-        self.steam_step_counter = 0
+        self.stream_step_counter = 0
         self.env = env
         self.coord_list = []
         if hasattr(env, "pyboy"):
@@ -36,7 +37,7 @@ class StreamWrapper(gym.Wrapper):
         map_n = self.emulator.get_memory_value(MAP_N_ADDRESS)
         self.coord_list.append([x_pos, y_pos, map_n])
 
-        if self.steam_step_counter >= self.upload_interval:
+        if self.stream_step_counter >= self.upload_interval:
             self.stream_metadata["extra"] = f"coords: {len(self.env.seen_coords)}"
             self.loop.run_until_complete(
                 self.broadcast_ws_message(
@@ -48,10 +49,10 @@ class StreamWrapper(gym.Wrapper):
                     )
                 )
             )
-            self.steam_step_counter = 0
+            self.stream_step_counter = 0
             self.coord_list = []
 
-        self.steam_step_counter += 1
+        self.stream_step_counter += 1
 
         return self.env.step(action)
 
@@ -61,11 +62,20 @@ class StreamWrapper(gym.Wrapper):
         if self.websocket is not None:
             try:
                 await self.websocket.send(message)
-            except websockets.exceptions.WebSocketException as e:
+            except websockets.exceptions.WebSocketException:
+                logging.exception("Websocket send failed, attempting to reconnect")
                 self.websocket = None
+                await self.establish_wc_connection()
+                if self.websocket is not None:
+                    try:
+                        await self.websocket.send(message)
+                    except websockets.exceptions.WebSocketException:
+                        logging.exception("Reconnect attempt failed")
+                        self.websocket = None
 
     async def establish_wc_connection(self):
         try:
             self.websocket = await websockets.connect(self.ws_address)
-        except:
+        except Exception as e:
+            logging.exception("Failed to establish websocket connection")
             self.websocket = None

--- a/tests/test_stream_agent_wrapper.py
+++ b/tests/test_stream_agent_wrapper.py
@@ -1,0 +1,93 @@
+import asyncio
+import unittest
+from unittest import mock
+
+try:
+    import websockets
+except ModuleNotFoundError:  # Provide minimal stub if websockets not installed
+    import types, sys
+    async def _dummy_connect(*args, **kwargs):
+        return None
+    websockets = types.SimpleNamespace(
+        exceptions=types.SimpleNamespace(WebSocketException=Exception, ConnectionClosed=Exception),
+        connect=_dummy_connect
+    )
+    sys.modules['websockets'] = websockets
+
+try:
+    import gymnasium as gym
+except ModuleNotFoundError:
+    import types, sys
+    class DummyWrapper:
+        def __init__(self, env):
+            self.env = env
+    gym = types.SimpleNamespace(Wrapper=DummyWrapper)
+    sys.modules['gymnasium'] = gym
+
+import v2.stream_agent_wrapper as v2_wrapper
+import baselines.stream_agent_wrapper as base_wrapper
+
+class DummyEmulator:
+    def __init__(self):
+        self.memory = {v2_wrapper.X_POS_ADDRESS: 0,
+                       v2_wrapper.Y_POS_ADDRESS: 0,
+                       v2_wrapper.MAP_N_ADDRESS: 0}
+    def get_memory_value(self, addr):
+        return self.memory.get(addr, 0)
+
+class DummyEnv:
+    def __init__(self):
+        self.pyboy = DummyEmulator()
+        self.seen_coords = []
+    def step(self, action):
+        return "obs", 0, False, False, {}
+
+def make_wrapper(module):
+    env = DummyEnv()
+    wrapper = module.StreamWrapper(env)
+    wrapper.upload_interval = 1
+    return wrapper
+
+class FakeWebSocket:
+    def __init__(self, fail=False):
+        self.sent = []
+        self.fail = fail
+    async def send(self, message):
+        if self.fail:
+            self.fail = False
+            raise websockets.exceptions.ConnectionClosed(1000, "closed")
+        self.sent.append(message)
+
+def run_step(wrapper, times=1):
+    result = None
+    for _ in range(times):
+        result = wrapper.step(0)
+    return result
+
+class StreamWrapperTests(unittest.TestCase):
+    def test_counter_increment(self):
+        for module in (v2_wrapper, base_wrapper):
+            ws = FakeWebSocket()
+            async def connect_mock(*args, **kwargs):
+                return ws
+            with mock.patch.object(module.websockets, 'connect', side_effect=connect_mock):
+                wrapper = make_wrapper(module)
+                self.assertEqual(wrapper.stream_step_counter, 0)
+                run_step(wrapper)
+                self.assertEqual(wrapper.stream_step_counter, 1)
+
+    def test_reconnect_on_failure(self):
+        for module in (v2_wrapper, base_wrapper):
+            ws1 = FakeWebSocket(fail=True)
+            ws2 = FakeWebSocket()
+            connect_results = [ws1, ws2]
+            async def connect_mock(*args, **kwargs):
+                return connect_results.pop(0)
+            with mock.patch.object(module.websockets, 'connect', side_effect=connect_mock) as connect_mock:
+                wrapper = make_wrapper(module)
+                run_step(wrapper, times=2)  # second step triggers send and reconnect
+                self.assertEqual(connect_mock.call_count, 2)
+                self.assertEqual(len(ws2.sent), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename `steam_step_counter` to `stream_step_counter`
- log websocket errors and attempt reconnection
- add reconnection logic to both stream wrappers
- unit tests for counter and reconnect behaviour

## Testing
- `python -m unittest tests/test_stream_agent_wrapper.py`