### PR TITLE
Use module relative paths for data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Follow this [guide to install pytorch with ROCm support](https://rocm.docs.amd.c
 
 V2 is now recommended over the original version. You may follow all steps below but replace `baselines` with `v2`.
 
-1. Copy your legally obtained Pokemon Red ROM into the base directory. You can find this using google, it should be 1MB. Rename it to `PokemonRed.gb` if it is not already. The sha1 sum should be `ea9bcae617fdf159b045185467ae58b2e4a48b9a`, which you can verify by running `shasum PokemonRed.gb`. 
-2. Move into the `baselines/` directory:  
+1. Copy your legally obtained Pokemon Red ROM into the base directory (or another directory of your choice). Rename it to `PokemonRed.gb` if it is not already. The sha1 sum should be `ea9bcae617fdf159b045185467ae58b2e4a48b9a`, which you can verify by running `shasum PokemonRed.gb`.
+   You may also place save states such as `init.state` in this directory. The training scripts resolve these paths relative to their own location, so they can be run from any working directory.
+2. Move into the `baselines/` directory:
  ```cd baselines```  
 3. Install dependencies:  
 ```pip install -r requirements.txt```  
@@ -46,7 +47,7 @@ It may be necessary in some cases to separately install the SDL libraries.
 Interact with the emulator using the arrow keys and the `a` and `s` keys (A and B buttons).  
 You can pause the AI's input during the game by editing `agent_enabled.txt`
 
-Note: the Pokemon.gb file MUST be in the main directory and your current directory MUST be the `baselines/` directory in order for this to work.
+Note: the ROM and state file locations are configurable. By default the scripts expect them in the repository root but any path can be supplied.
 
 ## Training the Model 🏋️ 
 

--- a/baselines/baseline_fast_minimal.py
+++ b/baselines/baseline_fast_minimal.py
@@ -21,8 +21,9 @@ def make_env(rank, seed=0):
     :param rank: (int) index of the subprocess
     """
     def _init():
+        base_dir = Path(__file__).resolve().parent.parent
         env = StreamWrapper(
-            PokeRedEnv('../PokemonRed.gb', '../has_pokedex_nballs.state'), 
+            PokeRedEnv(base_dir / 'PokemonRed.gb', base_dir / 'has_pokedex_nballs.state'),
             stream_metadata = { # All of this is part is optional
                 "user": "v3-test", # choose your own username
                 "env_id": rank, # environment identifier

--- a/baselines/global_map.py
+++ b/baselines/global_map.py
@@ -1,9 +1,9 @@
 # adapted from https://github.com/thatguy11325/pokemonred_puffer/blob/main/pokemonred_puffer/global_map.py
 
-import os
 import json
+from pathlib import Path
 
-MAP_PATH = os.path.join(os.path.dirname(__file__), "map_data.json")
+MAP_PATH = Path(__file__).resolve().parent / "map_data.json"
 PAD = 20
 GLOBAL_MAP_SHAPE = (444 + PAD * 2, 436 + PAD * 2)
 MAP_ROW_OFFSET = PAD

--- a/baselines/ray_exp/train_ray.py
+++ b/baselines/ray_exp/train_ray.py
@@ -7,11 +7,12 @@ from red_gym_env_ray import RedGymEnv
 ep_length = 2048 # 2048 * 8
 sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
 
+base_dir = Path(__file__).resolve().parents[2]
 env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../../has_pokedex_nballs.state', 'max_steps': ep_length, 
+            'action_freq': 24, 'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': ep_length,
             'print_rewards': False, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-            'gb_path': '../../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 500_000.0
+            'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 500_000.0
         }
 
 ray.init(num_gpus=1)

--- a/baselines/red_gym_env_minimal.py
+++ b/baselines/red_gym_env_minimal.py
@@ -73,7 +73,8 @@ class PokeRedEnv(Env):
         ]
 
         # load event names (parsed from https://github.com/pret/pokered/blob/91dc3c9f9c8fd529bb6e8307b58b96efa0bec67e/constants/event_constants.asm)
-        with open("events.json") as f:
+        events_path = Path(__file__).resolve().parent / "events.json"
+        with open(events_path) as f:
             event_names = json.load(f)
         self.event_names = event_names
 

--- a/baselines/render_all_needed_grids.py
+++ b/baselines/render_all_needed_grids.py
@@ -28,11 +28,12 @@ def run_save(save):
     save = Path(save)
     ep_length = 2048 * 8
     sess_path = f'grid_renders/session_{save.stem}'
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0
+                'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0
             }
     num_cpu = 40  # Also sets the number of episodes per training iteration
     env = SubprocVecEnv([make_env(i, env_config) for i in range(num_cpu)])

--- a/baselines/run_baseline_parallel.py
+++ b/baselines/run_baseline_parallel.py
@@ -29,11 +29,13 @@ if __name__ == '__main__':
     ep_length = 2048 * 8
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24,
+                'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'extra_buttons': False
             }
     

--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -31,11 +31,12 @@ if __name__ == '__main__':
     sess_id = str(uuid.uuid4())[:8]
     sess_path = Path(f'session_{sess_id}')
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'reward_scale': 4, 'extra_buttons': False,
                 'explore_weight': 3 # 2.5
             }

--- a/baselines/run_pretrained_interactive.py
+++ b/baselines/run_pretrained_interactive.py
@@ -28,11 +28,13 @@ if __name__ == '__main__':
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24,
+                'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
+                'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration

--- a/baselines/run_recorded_actions.py
+++ b/baselines/run_recorded_actions.py
@@ -11,11 +11,12 @@ def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_in
     action_list = [int(x) for x in list(action_arrays[run_index]["last_action"])]
     max_steps = len(action_list) - 1
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': max_steps, #ep_length, 
+            'action_freq': 24, 'init_state': base_dir / 'has_pokedex_nballs.state', 'max_steps': max_steps, #ep_length,
             'print_rewards': False, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-            'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
+            'gb_path': base_dir / 'PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
     }
     env = RedGymEnv(env_config)
     env.reset_count = run_index

--- a/v2/baseline_fast_v2.py
+++ b/v2/baseline_fast_v2.py
@@ -40,11 +40,15 @@ if __name__ == "__main__":
     sess_id = "runs"
     sess_path = Path(sess_id)
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': True, 'save_final_state': False, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
-                'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
+                'action_freq': 24,
+                'init_state': base_dir / 'init.state', 'max_steps': ep_length,
+                'print_rewards': True, 'save_video': False, 'fast_video': True,
+                'session_path': sess_path,
+                'gb_path': base_dir / 'PokemonRed.gb',
+                'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
             }
     
     print(env_config)

--- a/v2/global_map.py
+++ b/v2/global_map.py
@@ -1,9 +1,9 @@
 # adapted from https://github.com/thatguy11325/pokemonred_puffer/blob/main/pokemonred_puffer/global_map.py
 
-import os
 import json
+from pathlib import Path
 
-MAP_PATH = os.path.join(os.path.dirname(__file__), "map_data.json")
+MAP_PATH = Path(__file__).resolve().parent / "map_data.json"
 PAD = 20
 GLOBAL_MAP_SHAPE = (444 + PAD * 2, 436 + PAD * 2)
 MAP_ROW_OFFSET = PAD

--- a/v2/red_gym_env_v2.py
+++ b/v2/red_gym_env_v2.py
@@ -80,7 +80,8 @@ class RedGymEnv(Env):
         ]
 
         # load event names (parsed from https://github.com/pret/pokered/blob/91dc3c9f9c8fd529bb6e8307b58b96efa0bec67e/constants/event_constants.asm)
-        with open("events.json") as f:
+        events_path = Path(__file__).resolve().parent / "events.json"
+        with open(events_path) as f:
             event_names = json.load(f)
         self.event_names = event_names
 

--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -48,11 +48,15 @@ if __name__ == '__main__':
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
+    base_dir = Path(__file__).resolve().parent.parent
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
-                'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
+                'action_freq': 24,
+                'init_state': base_dir / 'init.state', 'max_steps': ep_length,
+                'print_rewards': True, 'save_video': False, 'fast_video': True,
+                'session_path': sess_path,
+                'gb_path': base_dir / 'PokemonRed.gb',
+                'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration


### PR DESCRIPTION
## Summary
- use `Path(__file__).resolve().parent` when loading resource files
- adjust baseline scripts to locate ROM/state files relative to their modules
- update README to mention configurable ROM and state directories

## Testing
- `python /workspace/PokemonRedExperiments/v2/baseline_fast_v2.py` *(fails: ModuleNotFoundError: No module named 'numpy')*