### PR TITLE
Improve path configuration for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,19 @@ Follow this [guide to install pytorch with ROCm support](https://rocm.docs.amd.c
 V2 is now recommended over the original version. You may follow all steps below but replace `baselines` with `v2`.
 
 1. Copy your legally obtained Pokemon Red ROM into the base directory. You can find this using google, it should be 1MB. Rename it to `PokemonRed.gb` if it is not already. The sha1 sum should be `ea9bcae617fdf159b045185467ae58b2e4a48b9a`, which you can verify by running `shasum PokemonRed.gb`. 
-2. Move into the `baselines/` directory:  
- ```cd baselines```  
-3. Install dependencies:  
+2. Move into the `baselines/` directory (optional, scripts now resolve paths relative to their location):
+ ```cd baselines```
+3. Install dependencies:
 ```pip install -r requirements.txt```  
 It may be necessary in some cases to separately install the SDL libraries.  
-4. Run:  
+4. Run:
 ```python run_pretrained_interactive.py```
+   - Use `--gb-path` or `--state-path` to override the ROM or state file location
   
 Interact with the emulator using the arrow keys and the `a` and `s` keys (A and B buttons).  
 You can pause the AI's input during the game by editing `agent_enabled.txt`
 
-Note: the Pokemon.gb file MUST be in the main directory and your current directory MUST be the `baselines/` directory in order for this to work.
+Note: The ROM and state paths default to files relative to each script. You may run the scripts from any directory.
 
 ## Training the Model 🏋️ 
 
@@ -64,6 +65,7 @@ Replaces the frame KNN with a coordinate based exploration reward, as well as so
 1. Previous steps but in the `v2` directory instead of `baselines`
 2. Run:
 ```python baseline_fast_v2.py```
+   - Add `--gb-path` or `--state-path` if your files are in custom locations
 
 ## Tracking Training Progress 📈
 

--- a/baselines/ray_exp/train_ray.py
+++ b/baselines/ray_exp/train_ray.py
@@ -1,17 +1,28 @@
 import uuid
 from pathlib import Path
 import ray
+import argparse
 from ray.rllib.algorithms import ppo
 from red_gym_env_ray import RedGymEnv
+
+DEFAULT_ROM = Path(__file__).resolve().parents[2] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[2] / "has_pokedex_nballs.state"
 
 ep_length = 2048 # 2048 * 8
 sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
 
+parser = argparse.ArgumentParser(description='Train with Ray')
+parser.add_argument('--gb-path', type=Path, default=DEFAULT_ROM,
+                    help='Path to Pokemon Red ROM')
+parser.add_argument('--state-path', type=Path, default=DEFAULT_STATE,
+                    help='Path to starting emulator state')
+args = parser.parse_args()
+
 env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../../has_pokedex_nballs.state', 'max_steps': ep_length, 
+            'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
             'print_rewards': False, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-            'gb_path': '../../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 500_000.0
+            'gb_path': str(args.gb_path), 'debug': False, 'sim_frame_dist': 500_000.0
         }
 
 ray.init(num_gpus=1)

--- a/baselines/render_all_needed_grids.py
+++ b/baselines/render_all_needed_grids.py
@@ -2,12 +2,16 @@ from os.path import exists
 from pathlib import Path
 import sys
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.callbacks import CheckpointCallback
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "has_pokedex_nballs.state"
 
 def make_env(rank, env_conf, seed=0):
     """
@@ -24,15 +28,15 @@ def make_env(rank, env_conf, seed=0):
     set_random_seed(seed)
     return _init
 
-def run_save(save):
+def run_save(save, gb_path, state_path):
     save = Path(save)
     ep_length = 2048 * 8
     sess_path = f'grid_renders/session_{save.stem}'
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0
+                'gb_path': str(gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0
             }
     num_cpu = 40  # Also sets the number of episodes per training iteration
     env = SubprocVecEnv([make_env(i, env_config) for i in range(num_cpu)])
@@ -64,7 +68,14 @@ def run_save(save):
 
 
 if __name__ == '__main__':
-    run_save(sys.argv[1])
+    parser = argparse.ArgumentParser(description='Render grids from checkpoint')
+    parser.add_argument('save', help='checkpoint file')
+    parser.add_argument('--gb-path', type=Path, default=DEFAULT_ROM,
+                        help='Path to Pokemon Red ROM')
+    parser.add_argument('--state-path', type=Path, default=DEFAULT_STATE,
+                        help='Path to starting emulator state')
+    args = parser.parse_args()
+    run_save(args.save, args.gb_path, args.state_path)
     
 #    all_saves = list(Path('session_4da05e87').glob('*.zip'))
 #    selected_saves = [Path('session_4da05e87/init')] + all_saves[:10] + all_saves[10:120:5] + all_saves[120:420:10]

--- a/baselines/run_baseline_parallel.py
+++ b/baselines/run_baseline_parallel.py
@@ -1,12 +1,16 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.callbacks import CheckpointCallback
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "has_pokedex_nballs.state"
 
 def make_env(rank, env_conf, seed=0):
     """
@@ -25,15 +29,22 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run parallel baseline")
+    parser.add_argument("--gb-path", type=Path, default=DEFAULT_ROM,
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE,
+                        help="Path to starting emulator state")
+    args = parser.parse_args()
+
 
     ep_length = 2048 * 8
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
 
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': str(args.gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'extra_buttons': False
             }
     

--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -1,6 +1,7 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
@@ -8,6 +9,9 @@ from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
 from tensorboard_callback import TensorboardCallback
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "has_pokedex_nballs.state"
 
 def make_env(rank, env_conf, seed=0):
     """
@@ -26,6 +30,13 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run parallel fast baseline")
+    parser.add_argument("--gb-path", type=Path, default=DEFAULT_ROM,
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE,
+                        help="Path to starting emulator state")
+    args = parser.parse_args()
+
     use_wandb_logging = False
     ep_length = 2048 * 10
     sess_id = str(uuid.uuid4())[:8]
@@ -33,9 +44,9 @@ if __name__ == '__main__':
 
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': str(args.gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'reward_scale': 4, 'extra_buttons': False,
                 'explore_weight': 3 # 2.5
             }

--- a/baselines/run_pretrained_interactive.py
+++ b/baselines/run_pretrained_interactive.py
@@ -1,7 +1,11 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "has_pokedex_nballs.state"
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -25,14 +29,21 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run pretrained model interactively")
+    parser.add_argument("--gb-path", type=Path, default=DEFAULT_ROM,
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE,
+                        help="Path to starting emulator state")
+    args = parser.parse_args()
+
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
+                'gb_path': str(args.gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration

--- a/baselines/run_recorded_actions.py
+++ b/baselines/run_recorded_actions.py
@@ -3,7 +3,12 @@ import pandas as pd
 import numpy as np
 from red_gym_env import RedGymEnv
 
-def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_index):
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "has_pokedex_nballs.state"
+
+def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_index,
+                                                    gb_path: Path = DEFAULT_ROM,
+                                                    state_path: Path = DEFAULT_STATE):
     sess_path = Path(f'session_{sess_id}')
     tdf = pd.read_csv(f"session_{sess_id}/agent_stats_{instance_id}.csv.gz", compression='gzip')
     tdf = tdf[tdf['map'] != 'map'] # remove unused 
@@ -13,9 +18,9 @@ def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_in
 
     env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': max_steps, #ep_length, 
+            'action_freq': 24, 'init_state': str(state_path), 'max_steps': max_steps, #ep_length,
             'print_rewards': False, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-            'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
+            'gb_path': str(gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
     }
     env = RedGymEnv(env_config)
     env.reset_count = run_index

--- a/v2/baseline_fast_v2.py
+++ b/v2/baseline_fast_v2.py
@@ -1,8 +1,12 @@
 import sys
 from os.path import exists
 from pathlib import Path
+import argparse
 from red_gym_env_v2 import RedGymEnv
 from stream_agent_wrapper import StreamWrapper
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "init.state"
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import SubprocVecEnv
@@ -35,6 +39,13 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == "__main__":
 
+    parser = argparse.ArgumentParser(description="Train fast v2 baseline")
+    parser.add_argument("--gb-path", type=Path, default=DEFAULT_ROM,
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE,
+                        help="Path to starting emulator state")
+    args = parser.parse_args()
+
     use_wandb_logging = False
     ep_length = 2048 * 80
     sess_id = "runs"
@@ -42,9 +53,9 @@ if __name__ == "__main__":
 
     env_config = {
                 'headless': True, 'save_final_state': False, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
+                'gb_path': str(args.gb_path), 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
             }
     
     print(env_config)

--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -2,9 +2,13 @@ import os
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 import time
 import glob
 from red_gym_env_v2 import RedGymEnv
+
+DEFAULT_ROM = Path(__file__).resolve().parents[1] / "PokemonRed.gb"
+DEFAULT_STATE = Path(__file__).resolve().parents[1] / "init.state"
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -45,14 +49,21 @@ def get_most_recent_zip_with_age(folder_path):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run pretrained v2 model interactively")
+    parser.add_argument("--gb-path", type=Path, default=DEFAULT_ROM,
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE,
+                        help="Path to starting emulator state")
+    args = parser.parse_args()
+
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.state_path), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
+                'gb_path': str(args.gb_path), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration


### PR DESCRIPTION
## Summary
- compute ROM and state defaults relative to each script
- add CLI options `--gb-path` and `--state-path`
- update README instructions for new path handling

## Testing
- `python -m py_compile baselines/baseline_fast_minimal.py v2/baseline_fast_v2.py baselines/run_pretrained_interactive.py v2/run_pretrained_interactive.py baselines/run_baseline_parallel_fast.py baselines/run_baseline_parallel.py baselines/render_all_needed_grids.py baselines/run_recorded_actions.py baselines/ray_exp/train_ray.py`