### PR TITLE
Add centralized memory module

### DIFF
--- a/baselines/memory_addresses.py
+++ b/baselines/memory_addresses.py
@@ -1,22 +1,6 @@
-# addresses from https://datacrystal.romhacking.net/wiki/Pok%C3%A9mon_Red/Blue:RAM_map
-# https://github.com/pret/pokered/blob/91dc3c9f9c8fd529bb6e8307b58b96efa0bec67e/constants/event_constants.asm
+"""Deprecated wrapper for backward compatibility.
 
-PARTY_SIZE_ADDRESS = 0xD163
-X_POS_ADDRESS, Y_POS_ADDRESS = 0xD362, 0xD361
-MAP_N_ADDRESS = 0xD35E
-BADGE_COUNT_ADDRESS = 0xD356
+All addresses have been moved to :mod:`poke_memory`.
+"""
 
-LEVELS_ADDRESSES = [0xD18C, 0xD1B8, 0xD1E4, 0xD210, 0xD23C, 0xD268]
-PARTY_ADDRESSES = [0xD164, 0xD165, 0xD166, 0xD167, 0xD168, 0xD169]
-OPPONENT_LEVELS_ADDRESSES = [0xD8C5, 0xD8F1, 0xD91D, 0xD949, 0xD975, 0xD9A1]
-
-EVENT_FLAGS_START_ADDRESS = 0xD747
-EVENT_FLAGS_END_ADDRESS = 0xD886
-MUSEUM_TICKET_ADDRESS = 0xD754
-
-HP_ADDRESSES = [0xD16C, 0xD198, 0xD1C4, 0xD1F0, 0xD21C, 0xD248]
-MAX_HP_ADDRESSES = [0xD18D, 0xD1B9, 0xD1E5, 0xD211, 0xD23D, 0xD269]
-
-MONEY_ADDRESS_1 = 0xD347
-MONEY_ADDRESS_2 = 0xD348
-MONEY_ADDRESS_3 = 0xD349
+from poke_memory import *  # noqa: F401,F403

--- a/baselines/ray_exp/red_gym_env_ray.py
+++ b/baselines/ray_exp/red_gym_env_ray.py
@@ -22,7 +22,7 @@ import gymnasium as gym
 from gymnasium import spaces
 
 from pyboy.utils import WindowEvent
-from memory_addresses import *
+from poke_memory import *
 
 class RedGymEnv(gym.Env):
 
@@ -432,7 +432,7 @@ class RedGymEnv(gym.Env):
         # addresses from https://datacrystal.romhacking.net/wiki/Pok%C3%A9mon_Red/Blue:RAM_map
         # https://github.com/pret/pokered/blob/91dc3c9f9c8fd529bb6e8307b58b96efa0bec67e/constants/event_constants.asm
         '''
-        num_poke = self.read_m(0xD163)
+        num_poke = self.read_m(PARTY_SIZE_ADDRESS)
         poke_xps = [self.read_triple(a) for a in [0xD179, 0xD1A5, 0xD1D1, 0xD1FD, 0xD229, 0xD255]]
         #money = self.read_money() - 975 # subtract starting money
         seen_poke_count = sum([self.bit_count(self.read_m(i)) for i in range(0xD30A, 0xD31D)])

--- a/baselines/red_gym_env.py
+++ b/baselines/red_gym_env.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from gymnasium import Env, spaces
 from pyboy.utils import WindowEvent
-from memory_addresses import *
+from poke_memory import *
 
 class RedGymEnv(Env):
 
@@ -501,7 +501,7 @@ class RedGymEnv(Env):
         # addresses from https://datacrystal.romhacking.net/wiki/Pok%C3%A9mon_Red/Blue:RAM_map
         # https://github.com/pret/pokered/blob/91dc3c9f9c8fd529bb6e8307b58b96efa0bec67e/constants/event_constants.asm
         '''
-        num_poke = self.read_m(0xD163)
+        num_poke = self.read_m(PARTY_SIZE_ADDRESS)
         poke_xps = [self.read_triple(a) for a in [0xD179, 0xD1A5, 0xD1D1, 0xD1FD, 0xD229, 0xD255]]
         #money = self.read_money() - 975 # subtract starting money
         seen_poke_count = sum([self.bit_count(self.read_m(i)) for i in range(0xD30A, 0xD31D)])

--- a/baselines/red_gym_env_minimal.py
+++ b/baselines/red_gym_env_minimal.py
@@ -13,9 +13,13 @@ from einops import repeat
 from gymnasium import Env, spaces
 from pyboy.utils import WindowEvent
 
-event_flags_start = 0xD747
-event_flags_end = 0xD7F6 # 0xD761 # 0xD886 temporarily lower event flag range for obs input
-museum_ticket = (0xD754, 0)
+from poke_memory import (
+    EVENT_FLAGS_START_ADDRESS as event_flags_start,
+    EVENT_FLAGS_END_ADDRESS as event_flags_end,
+    MUSEUM_TICKET_ADDRESS,
+    PARTY_SIZE_ADDRESS,
+)
+museum_ticket = (MUSEUM_TICKET_ADDRESS, 0)
 
 class PokeRedEnv(Env):
     def __init__(
@@ -153,7 +157,7 @@ class PokeRedEnv(Env):
 
         self.update_explore_map()
 
-        self.party_size = self.read_m(0xD163)
+        self.party_size = self.read_m(PARTY_SIZE_ADDRESS)
 
         self.last_health = self.read_hp_fraction()
 
@@ -224,7 +228,7 @@ class PokeRedEnv(Env):
                 "map_location": self.get_map_location(map_n),
                 "max_map_progress": self.max_map_progress,
                 "last_action": action,
-                "pcount": self.read_m(0xD163),
+                "pcount": self.read_m(PARTY_SIZE_ADDRESS),
                 "levels": levels,
                 "levels_sum": sum(levels),
                 "ptypes": self.read_party(),
@@ -333,7 +337,7 @@ class PokeRedEnv(Env):
     def update_heal_reward(self):
         cur_health = self.read_hp_fraction()
         # if health increased and party size did not change
-        if cur_health > self.last_health and self.read_m(0xD163) == self.party_size:
+        if cur_health > self.last_health and self.read_m(PARTY_SIZE_ADDRESS) == self.party_size:
             if self.last_health > 0:
                 # healed
                 pass

--- a/baselines/stream_agent_wrapper.py
+++ b/baselines/stream_agent_wrapper.py
@@ -4,8 +4,7 @@ import json
 
 import gymnasium as gym
 
-X_POS_ADDRESS, Y_POS_ADDRESS = 0xD362, 0xD361
-MAP_N_ADDRESS = 0xD35E
+from poke_memory import X_POS_ADDRESS, Y_POS_ADDRESS, MAP_N_ADDRESS
 
 class StreamWrapper(gym.Wrapper):
     def __init__(self, env, stream_metadata={}):

--- a/poke_memory.py
+++ b/poke_memory.py
@@ -1,0 +1,97 @@
+"""Shared constants and helpers for Pokemon Red emulator memory.
+
+This module centralizes all Game Boy RAM addresses used across the project
+and provides small helper utilities for reading values from a pyboy emulator
+instance.  The addresses are taken from documentation at
+https://datacrystal.romhacking.net and the pokered disassembly.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+# Core addresses
+PARTY_SIZE_ADDRESS = 0xD163
+X_POS_ADDRESS, Y_POS_ADDRESS = 0xD362, 0xD361
+MAP_N_ADDRESS = 0xD35E
+BADGE_COUNT_ADDRESS = 0xD356
+
+# Party related
+LEVELS_ADDRESSES = [0xD18C, 0xD1B8, 0xD1E4, 0xD210, 0xD23C, 0xD268]
+PARTY_ADDRESSES = [0xD164, 0xD165, 0xD166, 0xD167, 0xD168, 0xD169]
+OPPONENT_LEVELS_ADDRESSES = [0xD8C5, 0xD8F1, 0xD91D, 0xD949, 0xD975, 0xD9A1]
+
+# Event flags
+EVENT_FLAGS_START_ADDRESS = 0xD747
+EVENT_FLAGS_END_ADDRESS = 0xD886
+MUSEUM_TICKET_ADDRESS = 0xD754
+
+# Health related
+HP_ADDRESSES = [0xD16C, 0xD198, 0xD1C4, 0xD1F0, 0xD21C, 0xD248]
+MAX_HP_ADDRESSES = [0xD18D, 0xD1B9, 0xD1E5, 0xD211, 0xD23D, 0xD269]
+
+# Money
+MONEY_ADDRESS_1 = 0xD347
+MONEY_ADDRESS_2 = 0xD348
+MONEY_ADDRESS_3 = 0xD349
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _memory_view(emulator) -> Sequence[int]:
+    """Return a sequence-like view of emulator memory."""
+    if hasattr(emulator, "memory"):
+        return emulator.memory
+    if hasattr(emulator, "get_memory_value"):
+        class _Proxy(Sequence[int]):
+            def __getitem__(self, idx):
+                return emulator.get_memory_value(idx)
+            def __len__(self):
+                return 0x10000
+        return _Proxy()
+    raise TypeError("Unsupported emulator interface")
+
+
+def read_memory(emulator, addr: int) -> int:
+    """Read a single byte from ``addr``."""
+    return _memory_view(emulator)[addr]
+
+
+def read_bit(emulator, addr: int, bit: int) -> bool:
+    """Return ``True`` if the bit at ``addr`` is set."""
+    return bin(256 + read_memory(emulator, addr))[-bit - 1] == "1"
+
+
+def read_hp(emulator, start: int) -> int:
+    """Read a two-byte HP value starting at ``start``."""
+    mem = _memory_view(emulator)
+    return 256 * mem[start] + mem[start + 1]
+
+
+def read_hp_fraction(emulator) -> float:
+    """Return total party HP fraction."""
+    hp_sum = sum(read_hp(emulator, a) for a in HP_ADDRESSES)
+    max_hp_sum = sum(read_hp(emulator, a) for a in MAX_HP_ADDRESSES)
+    max_hp_sum = max(max_hp_sum, 1)
+    return hp_sum / max_hp_sum
+
+
+def read_party(emulator) -> list[int]:
+    """Return party species identifiers."""
+    return [read_memory(emulator, addr) for addr in PARTY_ADDRESSES]
+
+
+def read_event_bits(emulator) -> list[int]:
+    """Return event flag bits as a list of 0/1 integers."""
+    bits = []
+    for addr in range(EVENT_FLAGS_START_ADDRESS, EVENT_FLAGS_END_ADDRESS):
+        val = read_memory(emulator, addr)
+        bits.extend(int(b) for b in f"{val:08b}")
+    return bits
+
+
+def ensure_unique(addresses: Iterable[int]) -> bool:
+    """Utility used in tests to assert uniqueness of addresses."""
+    lst = list(addresses)
+    return len(lst) == len(set(lst))

--- a/tests/test_poke_memory.py
+++ b/tests/test_poke_memory.py
@@ -1,0 +1,31 @@
+import unittest
+import poke_memory as pm
+
+class TestPokeMemory(unittest.TestCase):
+    def test_required_addresses_present(self):
+        required = [
+            'X_POS_ADDRESS',
+            'Y_POS_ADDRESS',
+            'MAP_N_ADDRESS',
+            'HP_ADDRESSES',
+            'MAX_HP_ADDRESSES',
+            'EVENT_FLAGS_START_ADDRESS',
+            'EVENT_FLAGS_END_ADDRESS',
+        ]
+        for name in required:
+            self.assertTrue(hasattr(pm, name), f"{name} missing")
+
+    def test_coordinate_addresses_unique(self):
+        vals = [pm.X_POS_ADDRESS, pm.Y_POS_ADDRESS, pm.MAP_N_ADDRESS]
+        self.assertEqual(len(vals), len(set(vals)))
+
+    def test_hp_addresses_unique(self):
+        self.assertTrue(pm.ensure_unique(pm.HP_ADDRESSES))
+        self.assertTrue(pm.ensure_unique(pm.MAX_HP_ADDRESSES))
+        self.assertTrue(set(pm.HP_ADDRESSES).isdisjoint(pm.MAX_HP_ADDRESSES))
+
+    def test_event_flag_range_valid(self):
+        self.assertGreater(pm.EVENT_FLAGS_END_ADDRESS, pm.EVENT_FLAGS_START_ADDRESS)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v2/red_gym_env_v2.py
+++ b/v2/red_gym_env_v2.py
@@ -15,9 +15,13 @@ from pyboy.utils import WindowEvent
 
 from global_map import local_to_global, GLOBAL_MAP_SHAPE
 
-event_flags_start = 0xD747
-event_flags_end = 0xD87E # expand for SS Anne # old - 0xD7F6 
-museum_ticket = (0xD754, 0)
+from poke_memory import (
+    EVENT_FLAGS_START_ADDRESS as event_flags_start,
+    EVENT_FLAGS_END_ADDRESS as event_flags_end,
+    MUSEUM_TICKET_ADDRESS,
+    PARTY_SIZE_ADDRESS,
+)
+museum_ticket = (MUSEUM_TICKET_ADDRESS, 0)
 
 class RedGymEnv(Env):
     def __init__(self, config=None):
@@ -214,7 +218,7 @@ class RedGymEnv(Env):
 
         self.update_heal_reward()
 
-        self.party_size = self.read_m(0xD163)
+        self.party_size = self.read_m(PARTY_SIZE_ADDRESS)
 
         new_reward = self.update_reward()
 
@@ -272,7 +276,7 @@ class RedGymEnv(Env):
                 "map": map_n,
                 "max_map_progress": self.max_map_progress,
                 "last_action": action,
-                "pcount": self.read_m(0xD163),
+                "pcount": self.read_m(PARTY_SIZE_ADDRESS),
                 "levels": levels,
                 "levels_sum": sum(levels),
                 "ptypes": self.read_party(),
@@ -547,7 +551,7 @@ class RedGymEnv(Env):
     def update_heal_reward(self):
         cur_health = self.read_hp_fraction()
         # if health increased and party size did not change
-        if cur_health > self.last_health and self.read_m(0xD163) == self.party_size:
+        if cur_health > self.last_health and self.read_m(PARTY_SIZE_ADDRESS) == self.party_size:
             if self.last_health > 0:
                 heal_amount = cur_health - self.last_health
                 self.total_healing_rew += heal_amount * heal_amount

--- a/v2/stream_agent_wrapper.py
+++ b/v2/stream_agent_wrapper.py
@@ -4,8 +4,7 @@ import json
 
 import gymnasium as gym
 
-X_POS_ADDRESS, Y_POS_ADDRESS = 0xD362, 0xD361
-MAP_N_ADDRESS = 0xD35E
+from poke_memory import X_POS_ADDRESS, Y_POS_ADDRESS, MAP_N_ADDRESS
 
 class StreamWrapper(gym.Wrapper):
     def __init__(self, env, stream_metadata={}):


### PR DESCRIPTION
## Summary
- add `poke_memory.py` with RAM addresses and helper utilities
- refactor environment modules to import constants from the new module
- provide backward compatibility via `baselines/memory_addresses.py`
- include basic unit tests for address presence and uniqueness

## Testing
- `python -m unittest discover -s tests -v`