### PR TITLE
Fix event flag scanning and add tests

### DIFF
--- a/baselines/red_gym_env_minimal.py
+++ b/baselines/red_gym_env_minimal.py
@@ -165,19 +165,9 @@ class PokeRedEnv(Env):
 
         # self.save_and_print_info(step_limit_reached, obs)
 
-        # create a map of all event flags set, with names where possible
-        #if step_limit_reached:
+        # periodically update event flag cache
         if self.step_count % 100 == 0:
-            for address in range(event_flags_start, event_flags_end):
-                val = self.read_m(address)
-                for idx, bit in enumerate(f"{val:08b}"):
-                    if bit == "1":
-                        # TODO this currently seems to be broken!
-                        key = f"0x{address:X}-{idx}"
-                        if key in self.event_names.keys():
-                            self.current_event_flags_set[key] = self.event_names[key]
-                        else:
-                            print(f"could not find key: {key}")
+            self.scan_event_flags()
 
         self.step_count += 1
 
@@ -284,9 +274,24 @@ class PokeRedEnv(Env):
 
     def read_event_bits(self):
         return [
-            int(bit) for i in range(event_flags_start, event_flags_end) 
+            int(bit) for i in range(event_flags_start, event_flags_end)
             for bit in f"{self.read_m(i):08b}"
         ]
+
+    def generate_event_flag_key(self, address: int, bit: int) -> str:
+        """Return standardized event flag key."""
+        return f"0x{address:X}-{bit}"
+
+    def scan_event_flags(self):
+        """Populate ``current_event_flags_set`` with active flags."""
+        self.current_event_flags_set = {}
+        for address in range(event_flags_start, event_flags_end):
+            val = self.read_m(address)
+            for bit in range(8):
+                if val & (1 << bit):
+                    key = self.generate_event_flag_key(address, bit)
+                    if key in self.event_names:
+                        self.current_event_flags_set[key] = self.event_names[key]
 
     def get_levels_sum(self):
         min_poke_level = 2

--- a/tests/test_event_flags.py
+++ b/tests/test_event_flags.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+
+event_flags_start = 0xD747
+event_flags_end = 0xD87E
+
+class DummyEventEnv:
+    def __init__(self):
+        with open("v2/events.json") as f:
+            self.event_names = json.load(f)
+        self.memory = {addr: 0 for addr in range(event_flags_start, event_flags_end)}
+        self.current_event_flags_set = {}
+
+    def read_m(self, addr):
+        return self.memory.get(addr, 0)
+
+    def generate_event_flag_key(self, address: int, bit: int) -> str:
+        return f"0x{address:X}-{bit}"
+
+    def scan_event_flags(self):
+        self.current_event_flags_set = {}
+        for address in range(event_flags_start, event_flags_end):
+            val = self.read_m(address)
+            for bit in range(8):
+                if val & (1 << bit):
+                    key = self.generate_event_flag_key(address, bit)
+                    if key in self.event_names:
+                        self.current_event_flags_set[key] = self.event_names[key]
+
+    def set_flag(self, address: int, bit: int):
+        self.memory[address] |= (1 << bit)
+
+class TestEventScanning(unittest.TestCase):
+    def test_scan_event_flags_recognizes_set_flag(self):
+        env = DummyEventEnv()
+        key = list(env.event_names.keys())[0]
+        addr_str, bit_str = key.split("-")
+        address = int(addr_str, 16)
+        bit = int(bit_str)
+        env.set_flag(address, bit)
+        env.scan_event_flags()
+        self.assertIn(key, env.current_event_flags_set)
+        self.assertEqual(env.current_event_flags_set[key], env.event_names[key])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `scan_event_flags` helpers in gym envs
- ensure event flag keys match `0xADDR-BIT` format
- update step loops to call the new scan method
- add a unit test for event flag scanning

## Testing
- `python -m unittest discover -v tests`