### PR TITLE
Add argparse options to baseline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Replaces the frame KNN with a coordinate based exploration reward, as well as so
 1. Previous steps but in the `v2` directory instead of `baselines`
 2. Run:
 ```python baseline_fast_v2.py```
+You can override default paths with command line options:
+```bash
+python baseline_fast_v2.py --gb-path /path/PokemonRed.gb --init-state /path/init.state --session-dir my_runs
+```
 
 ## Tracking Training Progress 📈
 


### PR DESCRIPTION
## Summary
- allow overriding ROM, state, and session paths in `baseline_fast_v2.py`
- support the same overrides in minimal and parallel baseline scripts
- show usage of new arguments in README

## Testing
- `python -m py_compile v2/baseline_fast_v2.py baselines/baseline_fast_minimal.py baselines/run_baseline_parallel.py baselines/run_baseline_parallel_fast.py`