### PR TITLE
Fix event flag extraction

### DIFF
--- a/baselines/red_gym_env_minimal.py
+++ b/baselines/red_gym_env_minimal.py
@@ -170,11 +170,10 @@ class PokeRedEnv(Env):
         if self.step_count % 100 == 0:
             for address in range(event_flags_start, event_flags_end):
                 val = self.read_m(address)
-                for idx, bit in enumerate(f"{val:08b}"):
-                    if bit == "1":
-                        # TODO this currently seems to be broken!
-                        key = f"0x{address:X}-{idx}"
-                        if key in self.event_names.keys():
+                for bit_idx in range(8):
+                    if val & (1 << bit_idx):
+                        key = f"0x{address:04X}-{bit_idx}"
+                        if key in self.event_names:
                             self.current_event_flags_set[key] = self.event_names[key]
                         else:
                             print(f"could not find key: {key}")
@@ -283,10 +282,11 @@ class PokeRedEnv(Env):
         return bin(256 + self.read_m(addr))[-bit - 1] == "1"
 
     def read_event_bits(self):
-        return [
-            int(bit) for i in range(event_flags_start, event_flags_end) 
-            for bit in f"{self.read_m(i):08b}"
-        ]
+        bits = []
+        for i in range(event_flags_start, event_flags_end):
+            val = self.read_m(i)
+            bits.extend([(val >> b) & 1 for b in range(8)])
+        return bits
 
     def get_levels_sum(self):
         min_poke_level = 2

--- a/tests/test_event_flags.py
+++ b/tests/test_event_flags.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+
+EVENT_FLAGS_START = 0xD747
+EVENT_FLAGS_END = 0xD7F6
+
+class DummyEnv:
+    def __init__(self, memory, event_names):
+        self.memory = memory
+        self.event_names = event_names
+        self.current_event_flags_set = {}
+
+    def read_m(self, addr):
+        return self.memory[addr]
+
+    def update_flags(self):
+        for address in range(EVENT_FLAGS_START, EVENT_FLAGS_END):
+            val = self.read_m(address)
+            for bit_idx in range(8):
+                if val & (1 << bit_idx):
+                    key = f"0x{address:04X}-{bit_idx}"
+                    if key in self.event_names:
+                        self.current_event_flags_set[key] = self.event_names[key]
+
+def test_event_flag_lookup():
+    events_path = Path("v2/events.json")
+    with events_path.open() as f:
+        event_names = json.load(f)
+
+    memory = bytearray(0x10000)
+    memory[EVENT_FLAGS_START] = 0b00000001  # set bit 0
+
+    env = DummyEnv(memory, event_names)
+    env.update_flags()
+
+    assert env.current_event_flags_set.get("0xD747-0") == event_names["0xD747-0"]

--- a/v2/red_gym_env_v2.py
+++ b/v2/red_gym_env_v2.py
@@ -233,11 +233,10 @@ class RedGymEnv(Env):
         if self.step_count % 100 == 0:
             for address in range(event_flags_start, event_flags_end):
                 val = self.read_m(address)
-                for idx, bit in enumerate(f"{val:08b}"):
-                    if bit == "1":
-                        # TODO this currently seems to be broken!
-                        key = f"0x{address:X}-{idx}"
-                        if key in self.event_names.keys():
+                for bit_idx in range(8):
+                    if val & (1 << bit_idx):
+                        key = f"0x{address:04X}-{bit_idx}"
+                        if key in self.event_names:
                             self.current_event_flags_set[key] = self.event_names[key]
                         else:
                             print(f"could not find key: {key}")
@@ -465,10 +464,11 @@ class RedGymEnv(Env):
         return bin(256 + self.read_m(addr))[-bit - 1] == "1"
 
     def read_event_bits(self):
-        return [
-            int(bit) for i in range(event_flags_start, event_flags_end) 
-            for bit in f"{self.read_m(i):08b}"
-        ]
+        bits = []
+        for i in range(event_flags_start, event_flags_end):
+            val = self.read_m(i)
+            bits.extend([(val >> b) & 1 for b in range(8)])
+        return bits
 
     def get_levels_sum(self):
         min_poke_level = 2


### PR DESCRIPTION
## Summary
- fix bit index order when decoding event flags
- add regression test for event flag naming

## Testing
- `python tests/test_event_flags.py && echo OK`
