### PR TITLE
Add CLI args for ROM and state paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ V2 is now recommended over the original version. You may follow all steps below 
 3. Install dependencies:  
 ```pip install -r requirements.txt```  
 It may be necessary in some cases to separately install the SDL libraries.  
-4. Run:  
+4. Run:
 ```python run_pretrained_interactive.py```
+You can override the ROM or state paths with `--rom` and `--init-state` if needed.
   
 Interact with the emulator using the arrow keys and the `a` and `s` keys (A and B buttons).  
 You can pause the AI's input during the game by editing `agent_enabled.txt`
 
-Note: the Pokemon.gb file MUST be in the main directory and your current directory MUST be the `baselines/` directory in order for this to work.
+The scripts default to loading `PokemonRed.gb` and the initial state from the project root.
+Specify alternative locations with the `--rom` and `--init-state` options if desired.
 
 ## Training the Model 🏋️ 
 
@@ -64,6 +66,7 @@ Replaces the frame KNN with a coordinate based exploration reward, as well as so
 1. Previous steps but in the `v2` directory instead of `baselines`
 2. Run:
 ```python baseline_fast_v2.py```
+Use `--rom` and `--init-state` to point to different files if they are not in the project root.
 
 ## Tracking Training Progress 📈
 

--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -1,7 +1,15 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
+
+
+def find_project_root() -> Path:
+    path = Path(__file__).resolve()
+    while not (path / "README.md").exists() and path.parent != path:
+        path = path.parent
+    return path
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -26,6 +34,15 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Fast parallel baseline trainer")
+    project_root = find_project_root()
+    parser.add_argument('--rom', type=Path, default=project_root / 'PokemonRed.gb',
+                        help='Path to Pokemon Red ROM')
+    parser.add_argument('--init-state', type=Path,
+                        default=project_root / 'has_pokedex_nballs.state',
+                        help='Path to initial state file')
+    args = parser.parse_args()
+
     use_wandb_logging = False
     ep_length = 2048 * 10
     sess_id = str(uuid.uuid4())[:8]
@@ -33,9 +50,9 @@ if __name__ == '__main__':
 
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.init_state), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': str(args.rom), 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'reward_scale': 4, 'extra_buttons': False,
                 'explore_weight': 3 # 2.5
             }

--- a/baselines/run_pretrained_interactive.py
+++ b/baselines/run_pretrained_interactive.py
@@ -1,7 +1,15 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+import argparse
 from red_gym_env import RedGymEnv
+
+
+def find_project_root() -> Path:
+    path = Path(__file__).resolve()
+    while not (path / "README.md").exists() and path.parent != path:
+        path = path.parent
+    return path
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -25,14 +33,23 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run a pretrained model interactively")
+    project_root = find_project_root()
+    parser.add_argument('--rom', type=Path, default=project_root / 'PokemonRed.gb',
+                        help='Path to Pokemon Red ROM')
+    parser.add_argument('--init-state', type=Path,
+                        default=project_root / 'has_pokedex_nballs.state',
+                        help='Path to initial state file')
+    args = parser.parse_args()
+
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.init_state), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
+                'gb_path': str(args.rom), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration

--- a/baselines/run_recorded_actions.py
+++ b/baselines/run_recorded_actions.py
@@ -1,9 +1,17 @@
 from pathlib import Path
 import pandas as pd
 import numpy as np
+import argparse
 from red_gym_env import RedGymEnv
 
-def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_index):
+
+def find_project_root() -> Path:
+    path = Path(__file__).resolve()
+    while not (path / "README.md").exists() and path.parent != path:
+        path = path.parent
+    return path
+
+def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_index, rom_path: Path, state_path: Path):
     sess_path = Path(f'session_{sess_id}')
     tdf = pd.read_csv(f"session_{sess_id}/agent_stats_{instance_id}.csv.gz", compression='gzip')
     tdf = tdf[tdf['map'] != 'map'] # remove unused 
@@ -13,9 +21,9 @@ def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_in
 
     env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': max_steps, #ep_length, 
+            'action_freq': 24, 'init_state': str(state_path), 'max_steps': max_steps, #ep_length,
             'print_rewards': False, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-            'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
+            'gb_path': str(rom_path), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
     }
     env = RedGymEnv(env_config)
     env.reset_count = run_index
@@ -24,3 +32,25 @@ def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_in
     for action in action_list:
         obs, rewards, term, trunc, info = env.step(action)
         env.render()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Replay recorded actions and save video")
+    parser.add_argument("session_id", help="Session identifier")
+    parser.add_argument("instance_id", help="Instance identifier")
+    parser.add_argument("run_index", type=int, help="Run index to replay")
+    project_root = find_project_root()
+    parser.add_argument("--rom", type=Path, default=project_root / "PokemonRed.gb",
+                        help="Path to Pokemon Red ROM")
+    parser.add_argument("--init-state", type=Path,
+                        default=project_root / "has_pokedex_nballs.state",
+                        help="Path to initial state file")
+    args = parser.parse_args()
+
+    run_recorded_actions_on_emulator_and_save_video(
+        args.session_id,
+        args.instance_id,
+        args.run_index,
+        args.rom,
+        args.init_state,
+    )

--- a/v2/baseline_fast_v2.py
+++ b/v2/baseline_fast_v2.py
@@ -1,8 +1,16 @@
 import sys
 from os.path import exists
 from pathlib import Path
+import argparse
 from red_gym_env_v2 import RedGymEnv
 from stream_agent_wrapper import StreamWrapper
+
+
+def find_project_root() -> Path:
+    path = Path(__file__).resolve()
+    while not (path / "README.md").exists() and path.parent != path:
+        path = path.parent
+    return path
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import SubprocVecEnv
@@ -35,6 +43,15 @@ def make_env(rank, env_conf, seed=0):
 
 if __name__ == "__main__":
 
+    parser = argparse.ArgumentParser(description="V2 baseline trainer")
+    project_root = find_project_root()
+    parser.add_argument('--rom', type=Path, default=project_root / 'PokemonRed.gb',
+                        help='Path to Pokemon Red ROM')
+    parser.add_argument('--init-state', type=Path,
+                        default=project_root / 'init.state',
+                        help='Path to initial state file')
+    args = parser.parse_args()
+
     use_wandb_logging = False
     ep_length = 2048 * 80
     sess_id = "runs"
@@ -42,9 +59,9 @@ if __name__ == "__main__":
 
     env_config = {
                 'headless': True, 'save_final_state': False, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.init_state), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
+                'gb_path': str(args.rom), 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
             }
     
     print(env_config)

--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -4,7 +4,15 @@ from pathlib import Path
 import uuid
 import time
 import glob
+import argparse
 from red_gym_env_v2 import RedGymEnv
+
+
+def find_project_root() -> Path:
+    path = Path(__file__).resolve()
+    while not (path / "README.md").exists() and path.parent != path:
+        path = path.parent
+    return path
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -45,14 +53,23 @@ def get_most_recent_zip_with_age(folder_path):
 
 if __name__ == '__main__':
 
+    parser = argparse.ArgumentParser(description="Run V2 pretrained model interactively")
+    project_root = find_project_root()
+    parser.add_argument('--rom', type=Path, default=project_root / 'PokemonRed.gb',
+                        help='Path to Pokemon Red ROM')
+    parser.add_argument('--init-state', type=Path,
+                        default=project_root / 'init.state',
+                        help='Path to initial state file')
+    args = parser.parse_args()
+
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': str(args.init_state), 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
+                'gb_path': str(args.rom), 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration


### PR DESCRIPTION
## Summary
- add `--rom` and `--init-state` options for training and helper scripts
- look for ROM and state in project root by default
- document new CLI options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`