### PR TITLE
Ignore pycache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__
+baselines/__pycache__/
+v2/__pycache__/
 .DS_Store
 rollouts
 *.gb


### PR DESCRIPTION
## Summary
- ensure `baselines/__pycache__/` and `v2/__pycache__/` are ignored

## Testing
- `pytest -q` *(fails: command not found)*