### PR TITLE
Add config loader for ROM paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@ V2 is now recommended over the original version. You may follow all steps below 
 3. Install dependencies:  
 ```pip install -r requirements.txt```  
 It may be necessary in some cases to separately install the SDL libraries.  
-4. Run:  
-```python run_pretrained_interactive.py```
+4. Run:
+```bash
+python run_pretrained_interactive.py --gb_path /path/to/PokemonRed.gb --init_state /path/to/your.state
+```
   
 Interact with the emulator using the arrow keys and the `a` and `s` keys (A and B buttons).  
 You can pause the AI's input during the game by editing `agent_enabled.txt`
+
+Both commands above also accept a JSON config file via `--config config.json`.
 
 Note: the Pokemon.gb file MUST be in the main directory and your current directory MUST be the `baselines/` directory in order for this to work.
 
@@ -63,7 +67,10 @@ Note: the Pokemon.gb file MUST be in the main directory and your current directo
 Replaces the frame KNN with a coordinate based exploration reward, as well as some other tweaks.
 1. Previous steps but in the `v2` directory instead of `baselines`
 2. Run:
-```python baseline_fast_v2.py```
+```bash
+python baseline_fast_v2.py --gb_path /path/to/PokemonRed.gb --init_state /path/to/init.state
+```
+   You may also provide these paths in a JSON file and pass it via `--config myconf.json`.
 
 ## Tracking Training Progress 📈
 

--- a/baselines/run_baseline_parallel.py
+++ b/baselines/run_baseline_parallel.py
@@ -1,6 +1,8 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+
+from config_utils import load_paths
 from red_gym_env import RedGymEnv
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
@@ -29,11 +31,13 @@ if __name__ == '__main__':
     ep_length = 2048 * 8
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
 
+    gb_path, init_state = load_paths('../PokemonRed.gb', '../has_pokedex_nballs.state')
+
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': init_state, 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': gb_path, 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'extra_buttons': False
             }
     

--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -1,6 +1,8 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+
+from config_utils import load_paths
 from red_gym_env import RedGymEnv
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
@@ -31,11 +33,13 @@ if __name__ == '__main__':
     sess_id = str(uuid.uuid4())[:8]
     sess_path = Path(f'session_{sess_id}')
 
+    gb_path, init_state = load_paths('../PokemonRed.gb', '../has_pokedex_nballs.state')
+
     env_config = {
                 'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': init_state, 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
+                'gb_path': gb_path, 'debug': False, 'sim_frame_dist': 2_000_000.0,
                 'use_screen_explore': True, 'reward_scale': 4, 'extra_buttons': False,
                 'explore_weight': 3 # 2.5
             }

--- a/baselines/run_pretrained_interactive.py
+++ b/baselines/run_pretrained_interactive.py
@@ -1,6 +1,8 @@
 from os.path import exists
 from pathlib import Path
 import uuid
+
+from config_utils import load_paths
 from red_gym_env import RedGymEnv
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
@@ -28,11 +30,13 @@ if __name__ == '__main__':
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
+    gb_path, init_state = load_paths('../PokemonRed.gb', '../has_pokedex_nballs.state')
+
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': init_state, 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
+                'gb_path': gb_path, 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': True
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration

--- a/baselines/run_recorded_actions.py
+++ b/baselines/run_recorded_actions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 from red_gym_env import RedGymEnv
+from config_utils import load_paths
 
 def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_index):
     sess_path = Path(f'session_{sess_id}')
@@ -11,11 +12,13 @@ def run_recorded_actions_on_emulator_and_save_video(sess_id, instance_id, run_in
     action_list = [int(x) for x in list(action_arrays[run_index]["last_action"])]
     max_steps = len(action_list) - 1
 
+    gb_path, init_state = load_paths('../PokemonRed.gb', '../has_pokedex_nballs.state')
+
     env_config = {
             'headless': True, 'save_final_state': True, 'early_stop': False,
-            'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': max_steps, #ep_length, 
+            'action_freq': 24, 'init_state': init_state, 'max_steps': max_steps, #ep_length,
             'print_rewards': False, 'save_video': True, 'fast_video': False, 'session_path': sess_path,
-            'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
+            'gb_path': gb_path, 'debug': False, 'sim_frame_dist': 2_000_000.0, 'instance_id': f'{instance_id}_recorded'
     }
     env = RedGymEnv(env_config)
     env.reset_count = run_index

--- a/config_utils.py
+++ b/config_utils.py
@@ -1,0 +1,37 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Tuple
+
+
+def load_paths(default_gb_path: str = '../PokemonRed.gb',
+               default_init_state: str = '../init.state') -> Tuple[str, str]:
+    """Load paths to ROM and initial state.
+
+    Parameters
+    ----------
+    default_gb_path : str
+        Default path to the Game Boy ROM.
+    default_init_state : str
+        Default path to the emulator initial state.
+
+    Returns
+    -------
+    Tuple[str, str]
+        ``(gb_path, init_state)`` from command line or optional JSON config.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--config', type=str,
+                        help='JSON file containing "gb_path" and "init_state".')
+    parser.add_argument('--gb_path', type=str, help='Path to PokemonRed.gb')
+    parser.add_argument('--init_state', type=str, help='Path to emulator state')
+    args, _ = parser.parse_known_args()
+
+    config_data = {}
+    if args.config:
+        with open(Path(args.config), 'r') as f:
+            config_data = json.load(f)
+
+    gb_path = args.gb_path or config_data.get('gb_path', default_gb_path)
+    init_state = args.init_state or config_data.get('init_state', default_init_state)
+    return gb_path, init_state

--- a/v2/baseline_fast_v2.py
+++ b/v2/baseline_fast_v2.py
@@ -2,6 +2,7 @@ import sys
 from os.path import exists
 from pathlib import Path
 from red_gym_env_v2 import RedGymEnv
+from config_utils import load_paths
 from stream_agent_wrapper import StreamWrapper
 from stable_baselines3 import PPO
 from stable_baselines3.common import env_checker
@@ -40,11 +41,12 @@ if __name__ == "__main__":
     sess_id = "runs"
     sess_path = Path(sess_id)
 
+    gb_path, init_state = load_paths()
     env_config = {
                 'headless': True, 'save_final_state': False, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': init_state, 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
+                'gb_path': gb_path, 'debug': False, 'reward_scale': 0.5, 'explore_weight': 0.25
             }
     
     print(env_config)

--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import uuid
 import time
 import glob
+from config_utils import load_paths
 from red_gym_env_v2 import RedGymEnv
 from stable_baselines3 import A2C, PPO
 from stable_baselines3.common import env_checker
@@ -48,11 +49,13 @@ if __name__ == '__main__':
     sess_path = Path(f'session_{str(uuid.uuid4())[:8]}')
     ep_length = 2**23
 
+    gb_path, init_state = load_paths('../PokemonRed.gb', '../init.state')
+
     env_config = {
                 'headless': False, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../init.state', 'max_steps': ep_length, 
+                'action_freq': 24, 'init_state': init_state, 'max_steps': ep_length,
                 'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
+                'gb_path': gb_path, 'debug': False, 'sim_frame_dist': 2_000_000.0, 'extra_buttons': False
             }
     
     num_cpu = 1 #64 #46  # Also sets the number of episodes per training iteration


### PR DESCRIPTION
## Summary
- add `config_utils.load_paths()` to handle JSON/CLI inputs for ROM and state files
- update various training scripts to use this helper
- document CLI usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`