### PR TITLE
Add pytest config and minimal tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import numpy as np
+import pytest
+from enum import IntEnum, auto
+
+class DummyWindowEvent(IntEnum):
+    PRESS_ARROW_DOWN = auto()
+    PRESS_ARROW_LEFT = auto()
+    PRESS_ARROW_RIGHT = auto()
+    PRESS_ARROW_UP = auto()
+    PRESS_BUTTON_A = auto()
+    PRESS_BUTTON_B = auto()
+    PRESS_BUTTON_START = auto()
+    RELEASE_ARROW_DOWN = auto()
+    RELEASE_ARROW_LEFT = auto()
+    RELEASE_ARROW_RIGHT = auto()
+    RELEASE_ARROW_UP = auto()
+    RELEASE_BUTTON_A = auto()
+    RELEASE_BUTTON_B = auto()
+    RELEASE_BUTTON_START = auto()
+
+class DummyScreen:
+    def __init__(self):
+        self.ndarray = np.zeros((144, 160, 3), dtype=np.uint8)
+
+class DummyPyBoy:
+    def __init__(self, *args, **kwargs):
+        self.memory = bytearray(0x10000)
+        self.screen = DummyScreen()
+    def set_emulation_speed(self, speed):
+        pass
+    def load_state(self, f):
+        pass
+    def send_input(self, action):
+        self.last_input = action
+    def tick(self, steps=1, render=True):
+        pass
+
+def _install_pyboy(monkeypatch):
+    pyboy_module = types.ModuleType("pyboy")
+    utils_module = types.ModuleType("pyboy.utils")
+    utils_module.WindowEvent = DummyWindowEvent
+    pyboy_module.PyBoy = DummyPyBoy
+    pyboy_module.utils = utils_module
+    sys.modules["pyboy"] = pyboy_module
+    sys.modules["pyboy.utils"] = utils_module
+
+@pytest.fixture(autouse=True)
+def mock_pyboy(monkeypatch):
+    _install_pyboy(monkeypatch)
+    yield
+    sys.modules.pop("pyboy", None)
+    sys.modules.pop("pyboy.utils", None)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,53 @@
+import numpy as np
+from pathlib import Path
+from v2.red_gym_env_v2 import RedGymEnv, event_flags_start, event_flags_end
+
+
+def make_env(tmp_path):
+    config = {
+        'session_path': tmp_path,
+        'save_final_state': False,
+        'print_rewards': False,
+        'headless': True,
+        'init_state': str(Path('init.state')),
+        'action_freq': 1,
+        'max_steps': 10,
+        'save_video': False,
+        'fast_video': False,
+        'gb_path': 'PokemonRed.gb'
+    }
+    return RedGymEnv(config)
+
+
+def test_reset_observation_shapes(tmp_path):
+    env = make_env(tmp_path)
+    obs, info = env.reset()
+
+    assert obs['screens'].shape == (72, 80, env.frame_stacks)
+    assert obs['health'].shape == (1,)
+    assert obs['level'].shape == (env.enc_freqs,)
+    assert obs['badges'].shape == (8,)
+    assert obs['events'].shape == ((event_flags_end - event_flags_start) * 8,)
+    assert obs['map'].shape == (env.coords_pad*4, env.coords_pad*4, 1)
+    assert obs['recent_actions'].shape == (env.frame_stacks,)
+
+
+def test_step_increments_step_count(tmp_path):
+    env = make_env(tmp_path)
+    env.reset()
+    initial = env.step_count
+    env.step(0)
+    assert env.step_count == initial + 1
+
+
+def test_event_reward_and_explore_map(tmp_path):
+    env = make_env(tmp_path)
+    obs, _ = env.reset()
+    # set an event flag in memory
+    env.pyboy.memory[event_flags_start] = 0b00000001
+    reward_before = env.update_reward()
+    env.update_explore_map()
+    # event reward should now be positive
+    assert env.progress_reward['event'] >= 0
+    c = env.get_global_coords()
+    assert env.explore_map[c[0], c[1]] == 255


### PR DESCRIPTION
## Summary
- add pytest configuration
- mock PyBoy for testing
- test observation shapes, step counting, event rewards, and exploration map updates

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*