### PR TITLE
Handle websocket connection errors

### DIFF
--- a/baselines/stream_agent_wrapper.py
+++ b/baselines/stream_agent_wrapper.py
@@ -1,6 +1,7 @@
 import asyncio
 import websockets
 import json
+import logging
 
 import gymnasium as gym
 
@@ -74,5 +75,10 @@ class StreamWrapper(gym.Wrapper):
     async def establish_wc_connection(self):
         try:
             self.websocket = await websockets.connect(self.ws_address)
-        except:
+        except Exception as e:
+            logging.warning(
+                "Failed to establish websocket connection to %s: %s",
+                self.ws_address,
+                e,
+            )
             self.websocket = None

--- a/v2/stream_agent_wrapper.py
+++ b/v2/stream_agent_wrapper.py
@@ -1,6 +1,7 @@
 import asyncio
 import websockets
 import json
+import logging
 
 import gymnasium as gym
 
@@ -74,5 +75,10 @@ class StreamWrapper(gym.Wrapper):
     async def establish_wc_connection(self):
         try:
             self.websocket = await websockets.connect(self.ws_address)
-        except:
+        except Exception as e:
+            logging.warning(
+                "Failed to establish websocket connection to %s: %s",
+                self.ws_address,
+                e,
+            )
             self.websocket = None


### PR DESCRIPTION
## Summary
- log websocket connection failures in baselines `StreamWrapper`
- log websocket connection failures in v2 `StreamWrapper`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*