### PR TITLE
Add module docstrings

### DIFF
--- a/baselines/stream_agent_wrapper.py
+++ b/baselines/stream_agent_wrapper.py
@@ -1,3 +1,11 @@
+"""WebSocket broadcast wrapper for Gym environments.
+
+``StreamWrapper`` decorates an environment to send the player's in-game
+coordinates to ``wss://transdimensional.xyz/broadcast``. This enables live
+visualization of training progress on the shared online map. Wrap your Gym
+environment with this class prior to training.
+"""
+
 import asyncio
 import websockets
 import json

--- a/v2/stream_agent_wrapper.py
+++ b/v2/stream_agent_wrapper.py
@@ -1,3 +1,11 @@
+"""Legacy broadcast wrapper used by the v2 training scripts.
+
+This module exposes ``StreamWrapper`` which mirrors the v3 wrapper but
+reads emulator memory directly when collecting coordinates. Player positions
+are periodically sent to ``wss://transdimensional.xyz/broadcast`` so that
+training can be visualized on the shared map.
+"""
+
 import asyncio
 import websockets
 import json

--- a/v3/red_gym_env_v3.py
+++ b/v3/red_gym_env_v3.py
@@ -1,3 +1,12 @@
+"""Gym environment for training agents in Pokémon Red.
+
+This module defines :class:`RedGymEnv`, a ``gymnasium.Env`` subclass that
+drives the PyBoy emulator. It exposes game state (screens, health, badges,
+and event flags) as observations and translates discrete actions into button
+presses. The environment also manages save states, optional video capture and
+tracking exploration progress for reinforcement learning experiments.
+"""
+
 import uuid
 import json
 from pathlib import Path


### PR DESCRIPTION
## Summary
- document the v3 `RedGymEnv` environment
- document the broadcast wrappers used in baselines and v2

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*