### PR TITLE
Implement StreamWrapper close method

### DIFF
--- a/baselines/baseline_fast_minimal.py
+++ b/baselines/baseline_fast_minimal.py
@@ -91,3 +91,5 @@ if __name__ == "__main__":
 
     if use_wandb_logging:
         run.finish()
+
+    env.close()

--- a/baselines/run_baseline_parallel.py
+++ b/baselines/run_baseline_parallel.py
@@ -61,3 +61,5 @@ if __name__ == '__main__':
     
     for i in range(learn_steps):
         model.learn(total_timesteps=(ep_length)*num_cpu*1000, callback=checkpoint_callback)
+
+    env.close()

--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -83,3 +83,5 @@ if __name__ == '__main__':
 
     if use_wandb_logging:
         run.finish()
+
+    env.close()

--- a/baselines/stream_agent_wrapper.py
+++ b/baselines/stream_agent_wrapper.py
@@ -90,3 +90,18 @@ class StreamWrapper(gym.Wrapper):
                 e,
             )
             self.websocket = None
+
+    def close(self):
+        """Close WebSocket connection and underlying environment."""
+        if self.websocket is not None:
+            try:
+                self.loop.run_until_complete(self.websocket.close())
+            except Exception as e:  # pragma: no cover - best effort
+                logging.warning("Error closing websocket: %s", e)
+            finally:
+                self.websocket = None
+
+        if not self.loop.is_closed():
+            self.loop.close()
+
+        super().close()


### PR DESCRIPTION
## Summary
- add a `close` method to `StreamWrapper`
- close environments at the end of baseline scripts

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*